### PR TITLE
Run vm in headless mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@
 /repos/qt4/tool/rcc
 /repos/qt4/tool/uic
 
+/.vagrant/
+/*console.log

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 #project
-PROJECT ?= demo
+PROJECT ?= hello
+PROJECT_DIR ?= hello_tutorial
 
 # options: x86 arm
 TOOLCHAIN_TARGET    ?= arm
@@ -44,7 +45,7 @@ platform: genode_build_dir
 genode_build_dir:
 	tool/create_builddir $(GENODE_TARGET) BUILD_DIR=$(GENODE_BUILD_DIR)
 	printf 'REPOSITORIES += $$(GENODE_DIR)/repos/libports\n' >> $(BUILD_CONF)
-	printf 'REPOSITORIES += $$(GENODE_DIR)/repos/$(PROJECT)\n' >> $(BUILD_CONF) #add additional repos
+	printf 'REPOSITORIES += $$(GENODE_DIR)/repos/$(PROJECT_DIR)\n' >> $(BUILD_CONF) #add additional repos
 
 # Delete build directory for all target systems. In some cases, subfolders in the contrib directory might be corrupted. Remove manually and re-prepare if necessary.
 clean:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,7 +45,7 @@ Vagrant.configure("2") do |config|
   #
    config.vm.provider "virtualbox" do |vb|
   #   # Display the VirtualBox GUI when booting the machine
-     vb.gui = true
+     vb.gui = false
   #
   #   # Customize the amount of memory on the VM:
       vb.memory = 2048


### PR DESCRIPTION
* modifies the Vagrantfile to run without GUI
* "makes" hello_tutorial instead of demo by default, because demo requires a running GUI
* gitignore `/.vagrant/` and VM logfile

@BugUser0815 please review